### PR TITLE
Add Paste with Replace

### DIFF
--- a/SmartPaster2013/PkgCmdID.cs
+++ b/SmartPaster2013/PkgCmdID.cs
@@ -11,6 +11,7 @@ namespace SmartPaster2013
         public const uint cmdidPasteAsVerbatimString = 0x102;
         public const uint cmdidPasteAsStringBuilder = 0x103;
         public const uint cmdidPasteAsBytes = 0x104;
+        public const uint cmdidPasteWithReplace = 0x105;
 
     };
 }

--- a/SmartPaster2013/ReplaceForm.Designer.cs
+++ b/SmartPaster2013/ReplaceForm.Designer.cs
@@ -1,0 +1,109 @@
+﻿namespace SmartPaster2013
+{
+    partial class ReplaceForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.findTextBox = new System.Windows.Forms.TextBox();
+            this.replaceWithTextBox = new System.Windows.Forms.TextBox();
+            this.FindLabel = new System.Windows.Forms.Label();
+            this.ReplaceWithLabel = new System.Windows.Forms.Label();
+            this.pasteButton = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // findTextBox
+            // 
+            this.findTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.findTextBox.Location = new System.Drawing.Point(110, 13);
+            this.findTextBox.Name = "findTextBox";
+            this.findTextBox.Size = new System.Drawing.Size(459, 22);
+            this.findTextBox.TabIndex = 0;
+            // 
+            // replaceWithTextBox
+            // 
+            this.replaceWithTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.replaceWithTextBox.Location = new System.Drawing.Point(110, 41);
+            this.replaceWithTextBox.Name = "replaceWithTextBox";
+            this.replaceWithTextBox.Size = new System.Drawing.Size(459, 22);
+            this.replaceWithTextBox.TabIndex = 1;
+            // 
+            // FindLabel
+            // 
+            this.FindLabel.AutoSize = true;
+            this.FindLabel.Location = new System.Drawing.Point(12, 16);
+            this.FindLabel.Name = "FindLabel";
+            this.FindLabel.Size = new System.Drawing.Size(39, 17);
+            this.FindLabel.TabIndex = 2;
+            this.FindLabel.Text = "Find:";
+            // 
+            // ReplaceWithLabel
+            // 
+            this.ReplaceWithLabel.AutoSize = true;
+            this.ReplaceWithLabel.Location = new System.Drawing.Point(12, 46);
+            this.ReplaceWithLabel.Name = "ReplaceWithLabel";
+            this.ReplaceWithLabel.Size = new System.Drawing.Size(92, 17);
+            this.ReplaceWithLabel.TabIndex = 3;
+            this.ReplaceWithLabel.Text = "Replace with:";
+            // 
+            // pasteButton
+            // 
+            this.pasteButton.Location = new System.Drawing.Point(485, 70);
+            this.pasteButton.Name = "pasteButton";
+            this.pasteButton.Size = new System.Drawing.Size(84, 23);
+            this.pasteButton.TabIndex = 4;
+            this.pasteButton.Text = "Paste";
+            this.pasteButton.UseVisualStyleBackColor = true;
+            this.pasteButton.Click += new System.EventHandler(this.pasteButton_Click);
+            // 
+            // ReplaceForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(581, 101);
+            this.Controls.Add(this.pasteButton);
+            this.Controls.Add(this.ReplaceWithLabel);
+            this.Controls.Add(this.FindLabel);
+            this.Controls.Add(this.replaceWithTextBox);
+            this.Controls.Add(this.findTextBox);
+            this.Name = "ReplaceForm";
+            this.Text = "Find/Replace in paste text";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TextBox findTextBox;
+        private System.Windows.Forms.TextBox replaceWithTextBox;
+        private System.Windows.Forms.Label FindLabel;
+        private System.Windows.Forms.Label ReplaceWithLabel;
+        private System.Windows.Forms.Button pasteButton;
+    }
+}

--- a/SmartPaster2013/ReplaceForm.cs
+++ b/SmartPaster2013/ReplaceForm.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace SmartPaster2013
+{
+    public partial class ReplaceForm : Form
+    {
+        public ReplaceForm()
+        {
+            InitializeComponent();
+        }
+
+        private void pasteButton_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = DialogResult.OK;
+        }
+
+        public string TextToReplace
+            => this.findTextBox.Text;
+
+        public string ReplaceText
+            => this.replaceWithTextBox.Text;
+    }
+}

--- a/SmartPaster2013/ReplaceForm.resx
+++ b/SmartPaster2013/ReplaceForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/SmartPaster2013/SmartPaster.cs
+++ b/SmartPaster2013/SmartPaster.cs
@@ -211,6 +211,24 @@ namespace SmartPaster2013
                 SmartFormatter.StringbuilderizeInCs(ClipboardText, stringbuilder));
         }
 
+        public void PasteWithReplace(DTE2 application)
+        {
+            var replaceForm = new ReplaceForm();
+
+            // Show testDialog as a modal dialog and determine if DialogResult = OK.
+            if (replaceForm.ShowDialog() == DialogResult.OK)
+            {
+                var src = replaceForm.TextToReplace;
+                var dst = replaceForm.ReplaceText;
+                var txt = ClipboardText.Replace(src, dst);
+                Paste(application, txt);
+            }
+            else
+            {
+            }
+            replaceForm.Dispose();
+        }
+
         #endregion
     }
 }

--- a/SmartPaster2013/SmartPaster2013.csproj
+++ b/SmartPaster2013/SmartPaster2013.csproj
@@ -52,7 +52,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DeployExtension>False</DeployExtension>
+    <DeployExtension>True</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -174,6 +174,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Guids.cs" />
+    <Compile Include="ReplaceForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="ReplaceForm.Designer.cs">
+      <DependentUpon>ReplaceForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -187,6 +193,9 @@
     <Compile Include="PkgCmdID.cs" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="ReplaceForm.resx">
+      <DependentUpon>ReplaceForm.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/SmartPaster2013/SmartPaster2013.vsct
+++ b/SmartPaster2013/SmartPaster2013.vsct
@@ -112,6 +112,14 @@
           <ButtonText>Paste As StringBuilder</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidSmartPaster2013CmdSet" id="cmdidPasteWithReplace" priority="0x0100" type="Button">
+        <Parent guid="guidSmartPaster2013CmdSet" id="SubMenu" />
+        <Icon guid="guidSmartPaste" id="bmpPaste" />
+        <Strings>
+          <ButtonText>Paste with Replace</ButtonText>
+        </Strings>
+      </Button>
+
 
 
     </Buttons>
@@ -148,6 +156,7 @@
       <IDSymbol name="cmdidPasteAsVerbatimString" value="0x0102" />
       <IDSymbol name="cmdidPasteAsStringBuilder" value="0x0103" />
       <IDSymbol name="cmdidPasteAsBytes" value="0x0104" />
+      <IDSymbol name="cmdidPasteWithReplace" value="0x105" />
     </GuidSymbol>
 
     <GuidSymbol name="guidSmartPaste" value="{362530CF-350B-4997-B740-BAA96C37564D}">

--- a/SmartPaster2013/SmartPaster2013Package.cs
+++ b/SmartPaster2013/SmartPaster2013Package.cs
@@ -83,6 +83,10 @@ namespace SmartPaster2013
                 var menuCommandID = new CommandID(GuidList.guidSmartPaster2013CmdSet, (int)PkgCmdIDList.cmdidPasteAsComment);
                 var menuItem = new MenuCommand(CallPasteAsComment, menuCommandID);
                 mcs.AddCommand(menuItem);
+                
+                var menuCommandReplaceID = new CommandID(GuidList.guidSmartPaster2013CmdSet, (int)PkgCmdIDList.cmdidPasteWithReplace);
+                var menuItemReplace = new MenuCommand(CallPasteWithReplace, menuCommandReplaceID);
+                mcs.AddCommand(menuItemReplace);
 
             }
         }
@@ -128,6 +132,13 @@ namespace SmartPaster2013
             var dte = (DTE2)GetService(typeof(DTE));
             var sp = new SmartPaster();
             sp.PasteAsVerbatimString(dte);
+        }
+
+        private void CallPasteWithReplace(object sender, EventArgs e)
+        {
+            var dte = (DTE2)GetService(typeof(DTE));
+            var sp = new SmartPaster();
+            sp.PasteWithReplace(dte);
         }
 
     }


### PR DESCRIPTION
This change adds the possibility to make replacements in the clipboard text before it is pasted. Reason for this change is to be able to copy some text, then paste it with minor changes. 

Example: If you have different page objects like StartPage and ProductPage, and they should have the same logic in the constructor, you could copy the StartPage constructor, then Past with Replace , replacing "Start" with "Product" before the text is output to the editor window.
